### PR TITLE
Added  aria-labels and keyboard navigation to interactive elements closes #2 

### DIFF
--- a/CreditRoot/package-lock.json
+++ b/CreditRoot/package-lock.json
@@ -3531,18 +3531,6 @@
         }
       }
     },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",

--- a/CreditRoot/src/features/dashboard/components/AutoloanCard.jsx
+++ b/CreditRoot/src/features/dashboard/components/AutoloanCard.jsx
@@ -186,10 +186,11 @@ export function AutoloanCard({ lockedBalance = 0, walletAddress = null }) {
 
           <div className="mb-4">
             <div className="d-flex justify-content-between mb-2">
-              <label className="small text-white-50">Monto a solicitar</label>
+              <label id="loan-amount-label" className="small text-white-50">Monto a solicitar</label>
               <span className="fw-bold" style={{ color: '#fbbf24' }}>{formatCurrencyUsd(requested)}</span>
             </div>
             <input type="range" className="form-range mb-1"
+              aria-labelledby="loan-amount-label"
               min={10} max={Math.max(10, Math.floor(maxLoan))} step={5}
               value={requested}
               onChange={e => setRequested(Number(e.target.value))}
@@ -232,13 +233,15 @@ export function AutoloanCard({ lockedBalance = 0, walletAddress = null }) {
           {enoughBalance && (
             <button className="btn btn-sm w-100 rounded-3 mb-4"
               style={{ border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.4)', backgroundColor: 'transparent' }}
-              onClick={() => setShowSchedule(!showSchedule)}>
+              onClick={() => setShowSchedule(!showSchedule)}
+              aria-expanded={showSchedule}
+              aria-controls="payment-schedule">
               {showSchedule ? '▲ Ocultar tabla de pagos' : '▼ Ver tabla de pagos (24 meses)'}
             </button>
           )}
 
           {showSchedule && (
-            <div className="mb-4" style={{ maxHeight: 200, overflowY: 'auto' }}>
+            <div id="payment-schedule" className="mb-4" style={{ maxHeight: 200, overflowY: 'auto' }}>
               <table className="table table-dark table-borderless mb-0" style={{ fontSize: 12 }}>
                 <thead style={{ position: 'sticky', top: 0, backgroundColor: '#0c0c0c' }}>
                   <tr className="text-white-50">
@@ -266,7 +269,8 @@ export function AutoloanCard({ lockedBalance = 0, walletAddress = null }) {
               border: 'none', color: enoughBalance ? '#000' : 'rgba(255,255,255,0.2)',
               cursor: enoughBalance ? 'pointer' : 'not-allowed',
             }}
-            onClick={() => enoughBalance && setFase('confirmando')} disabled={!enoughBalance}>
+            onClick={() => enoughBalance && setFase('confirmando')} disabled={!enoughBalance}
+            aria-label={enoughBalance ? `Solicitar préstamo de ${formatCurrencyUsd(loan.amount)}` : 'Solicitar préstamo'}>
             🚨 Solicitar {enoughBalance ? formatCurrencyUsd(loan.amount) : '—'} de emergencia
           </button>
         </>
@@ -285,12 +289,14 @@ export function AutoloanCard({ lockedBalance = 0, walletAddress = null }) {
           <div className="d-flex gap-3 justify-content-center">
             <button className="btn btn-sm rounded-3 px-4"
               style={{ border: '1px solid rgba(255,255,255,0.15)', color: '#fff', backgroundColor: 'transparent' }}
-              onClick={() => setFase('form')}>
+              onClick={() => setFase('form')}
+              aria-label="Cancelar solicitud de préstamo">
               Cancelar
             </button>
             <button className="btn btn-sm rounded-3 px-4 fw-bold"
               style={{ background: 'linear-gradient(45deg, #d97706, #fbbf24)', border: 'none', color: '#000' }}
-              onClick={handleConfirmar}>
+              onClick={handleConfirmar}
+              aria-label="Confirmar y firmar préstamo">
               Confirmar y firmar
             </button>
           </div>
@@ -313,7 +319,8 @@ export function AutoloanCard({ lockedBalance = 0, walletAddress = null }) {
           <p className="small mb-3" style={{ color: '#f87171' }}>{errorMsg}</p>
           <button className="btn btn-sm rounded-3 px-4"
             style={{ border: '1px solid rgba(255,255,255,0.15)', color: '#fff', backgroundColor: 'transparent' }}
-            onClick={handleReset}>
+            onClick={handleReset}
+            aria-label="Intentar de nuevo">
             Intentar de nuevo
           </button>
         </div>
@@ -389,13 +396,15 @@ export function AutoloanCard({ lockedBalance = 0, walletAddress = null }) {
               {/* Pagar mes → transacción real */}
               <button className="btn btn-sm flex-fill rounded-3 fw-bold"
                 style={{ background: 'rgba(34,197,94,0.15)', border: '1px solid rgba(34,197,94,0.3)', color: '#22c55e' }}
-                onClick={handlePagarMes}>
+                onClick={handlePagarMes}
+                aria-label={`Pagar mes ${mesesPagadosReal + 1} del préstamo`}>
                 ✓ Pagar mes {mesesPagadosReal + 1}
               </button>
               {/* Fallar mes → solo actualiza UI de penalización, no hay tx */}
               <button className="btn btn-sm flex-fill rounded-3 fw-bold"
                 style={{ background: 'rgba(239,68,68,0.1)', border: '1px solid rgba(239,68,68,0.3)', color: '#f87171' }}
-                onClick={() => setMesesImpago(i => i + 1)}>
+                onClick={() => setMesesImpago(i => i + 1)}
+                aria-label="Fallar mes de pago (demo)">
                 ✗ Fallar mes (demo)
               </button>
             </div>
@@ -421,7 +430,8 @@ export function AutoloanCard({ lockedBalance = 0, walletAddress = null }) {
 
           <button className="btn btn-sm w-100 rounded-3"
             style={{ border: '1px solid rgba(255,255,255,0.1)', color: 'rgba(255,255,255,0.4)', backgroundColor: 'transparent' }}
-            onClick={handleReset}>
+            onClick={handleReset}
+            aria-label="Crear nueva solicitud de préstamo">
             Nueva solicitud
           </button>
         </>

--- a/CreditRoot/src/features/dashboard/components/RetirementSnapshot.jsx
+++ b/CreditRoot/src/features/dashboard/components/RetirementSnapshot.jsx
@@ -26,6 +26,32 @@ export function RetirementSnapshot() {
 
   const { cetesRate, userRate, platformRate, isLive } = useEtherfuseRate()
 
+  // Keyboard navigation for tabs
+  const handleTabKeyDown = (e, currentIndex) => {
+    let newIndex = currentIndex
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      e.preventDefault()
+      newIndex = (currentIndex + 1) % tabs.length
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      e.preventDefault()
+      newIndex = (currentIndex - 1 + tabs.length) % tabs.length
+    } else if (e.key === 'Home') {
+      e.preventDefault()
+      newIndex = 0
+    } else if (e.key === 'End') {
+      e.preventDefault()
+      newIndex = tabs.length - 1
+    } else {
+      return
+    }
+    setActiveTab(tabs[newIndex].key)
+    // Focus the new tab after state update
+    setTimeout(() => {
+      const newTab = document.getElementById(`tab-${tabs[newIndex].key}`)
+      if (newTab) newTab.focus()
+    }, 0)
+  }
+
   useEffect(() => {
     async function cargarDatos() {
       try {
@@ -151,9 +177,14 @@ export function RetirementSnapshot() {
             </div>
           </div>
 
-          <div className="d-flex gap-2 mb-4 pb-1" style={{ overflowX: 'auto', flexWrap: 'nowrap' }}>
-            {tabs.map((t) => (
+          <div role="tablist" className="d-flex gap-2 mb-4 pb-1" style={{ overflowX: 'auto', flexWrap: 'nowrap' }} aria-label="Dashboard sections">
+            {tabs.map((t, index) => (
               <button key={t.key}
+                id={`tab-${t.key}`}
+                role="tab"
+                aria-selected={activeTab === t.key}
+                aria-controls={`panel-${t.key}`}
+                tabIndex={activeTab === t.key ? 0 : -1}
                 className="btn btn-sm rounded-3 fw-bold flex-shrink-0"
                 style={{
                   backgroundColor: activeTab === t.key ? 'rgba(59,130,246,0.15)' : 'transparent',
@@ -161,14 +192,15 @@ export function RetirementSnapshot() {
                   color: activeTab === t.key ? '#f59e0b' : 'rgba(255,255,255,0.4)',
                   whiteSpace: 'nowrap',
                 }}
-                onClick={() => setActiveTab(t.key)}>
+                onClick={() => setActiveTab(t.key)}
+                onKeyDown={(e) => handleTabKeyDown(e, index)}>
                 {t.label}
               </button>
             ))}
           </div>
 
           {activeTab === 'resumen' && (
-            <div className="d-flex flex-column gap-4">
+            <div id="panel-resumen" role="tabpanel" aria-labelledby="tab-resumen" className="d-flex flex-column gap-4">
               <RateBadge />
               <div className="p-4 rounded-4" style={cardStyle}>
                 <h6 className="fw-bold mb-3">Estado del contrato</h6>
@@ -193,10 +225,10 @@ export function RetirementSnapshot() {
             </div>
           )}
 
-          {activeTab === 'historial' && <ContributionHistory walletAddress={address} lockedBalance={lockedBalance} depositCount={depositCount} />}
+          {activeTab === 'historial' && <div id="panel-historial" role="tabpanel" aria-labelledby="tab-historial"><ContributionHistory walletAddress={address} lockedBalance={lockedBalance} depositCount={depositCount} /></div>}
 
           {activeTab === 'ciclos' && (
-            <div className="p-4 rounded-4" style={cardStyle}>
+            <div id="panel-ciclos" role="tabpanel" aria-labelledby="tab-ciclos" className="p-4 rounded-4" style={cardStyle}>
               <div className="d-flex justify-content-between align-items-center mb-3">
                 <h6 className="fw-bold mb-0">Ciclos cada 5 años · $25 USDC/mes</h6>
                 <span className="badge rounded-pill" style={{ backgroundColor: 'rgba(251,191,36,0.1)', color: '#fbbf24', border: '1px solid rgba(251,191,36,0.2)' }}>
@@ -235,12 +267,12 @@ export function RetirementSnapshot() {
           )}
 
           {/* AutoloanCard recibe el saldo REAL del contrato y la dirección */}
-          {activeTab === 'prestamo' && <AutoloanCard lockedBalance={lockedBalance} walletAddress={address} />}
-          {activeTab === 'referidos' && <ReferralModule userName={address?.slice(0, 8) ?? 'usuario'} walletAddress={address} />}
-          {activeTab === 'carlos' && <CarlosSimulator />}
+          {activeTab === 'prestamo' && <div id="panel-prestamo" role="tabpanel" aria-labelledby="tab-prestamo"><AutoloanCard lockedBalance={lockedBalance} walletAddress={address} /></div>}
+          {activeTab === 'referidos' && <div id="panel-referidos" role="tabpanel" aria-labelledby="tab-referidos"><ReferralModule userName={address?.slice(0, 8) ?? 'usuario'} walletAddress={address} /></div>}
+          {activeTab === 'carlos' && <div id="panel-carlos" role="tabpanel" aria-labelledby="tab-carlos"><CarlosSimulator /></div>}
 
           {activeTab === 'ingresos' && (
-            <div className="p-4 rounded-4" style={cardStyle}>
+            <div id="panel-ingresos" role="tabpanel" aria-labelledby="tab-ingresos" className="p-4 rounded-4" style={cardStyle}>
               <h6 className="fw-bold mb-3">Distribución del rendimiento</h6>
               <div className="mb-4">
                 <div className="progress rounded-pill mb-2" style={{ height: 24, backgroundColor: 'rgba(255,255,255,0.05)' }}>

--- a/CreditRoot/src/screens/LandingScreen.jsx
+++ b/CreditRoot/src/screens/LandingScreen.jsx
@@ -45,11 +45,12 @@ function CalculadoraHero({ onRegister }) {
         {/* Sliders */}
         <div className="mb-4">
           <div className="d-flex justify-content-between mb-2">
-            <label className="small text-white-50">Aporte mensual</label>
+            <label id="cuota-label" className="small text-white-50">Aporte mensual</label>
             <span className="fw-bold small">${cuota} USDC</span>
           </div>
           <input type="range" className="form-range" min={2} max={500} step={1}
             value={cuota} onChange={e => setCuota(Number(e.target.value))}
+            aria-labelledby="cuota-label"
             style={{ accentColor: '#f59e0b' }} />
           <div className="d-flex justify-content-between">
             <span className="text-white-50" style={{ fontSize: 11 }}>$2 USDC</span>
@@ -59,11 +60,12 @@ function CalculadoraHero({ onRegister }) {
 
         <div className="mb-5">
           <div className="d-flex justify-content-between mb-2">
-            <label className="small text-white-50">Tiempo de ahorro</label>
+            <label id="anios-label" className="small text-white-50">Tiempo de ahorro</label>
             <span className="fw-bold small">{anios} años</span>
           </div>
           <input type="range" className="form-range" min={1} max={40}
             value={anios} onChange={e => setAnios(Number(e.target.value))}
+            aria-labelledby="anios-label"
             style={{ accentColor: '#f59e0b' }} />
           <div className="d-flex justify-content-between">
             <span className="text-white-50" style={{ fontSize: 11 }}>1 año</span>
@@ -74,7 +76,8 @@ function CalculadoraHero({ onRegister }) {
         <button
           className="btn btn-primary w-100 py-3 rounded-4 fw-bold fs-6"
           style={{ background: 'linear-gradient(45deg, #d97706, #f59e0b)', border: 'none' }}
-          onClick={onRegister}>
+          onClick={onRegister}
+          aria-label="Empezar a ahorrar">
           Empezar a ahorrar →
         </button>
       </div>
@@ -153,11 +156,13 @@ function CtaFinal({ onRegister, onLogin }) {
         <div className="d-flex gap-3 justify-content-center flex-wrap">
           <button className="btn btn-primary btn-lg px-5 py-3 rounded-4 fw-bold"
             style={{ background: 'linear-gradient(45deg, #d97706, #f59e0b)', border: 'none' }}
-            onClick={onRegister}>
+            onClick={onRegister}
+            aria-label="Crear cuenta gratis">
             Crear cuenta gratis
           </button>
           <button className="btn btn-outline-secondary btn-lg px-5 py-3 rounded-4 fw-bold"
-            onClick={onLogin}>
+            onClick={onLogin}
+            aria-label="Iniciar sesión con cuenta existente">
             Ya tengo cuenta
           </button>
         </div>
@@ -211,11 +216,13 @@ export function LandingScreen({ onLogin, onRegister }) {
             <div className="d-flex gap-3 flex-wrap d-lg-none">
               <button className="btn btn-primary btn-lg px-5 py-3 rounded-4 fw-bold"
                 style={{ background: 'linear-gradient(45deg, #d97706, #f59e0b)', border: 'none' }}
-                onClick={onRegister}>
+                onClick={onRegister}
+                aria-label="Comenzar ahora">
                 Comenzar ahora
               </button>
               <button className="btn btn-outline-secondary btn-lg px-4 py-3 rounded-4 fw-bold"
-                onClick={onLogin}>
+                onClick={onLogin}
+                aria-label="Iniciar sesión">
                 Iniciar sesión
               </button>
             </div>


### PR DESCRIPTION
## feat(accessibility): add aria-labels and keyboard navigation support

**Closes #2**

### Problem
The dashboard, landing page, and autoloan components lacked proper accessibility support:
- Range sliders had no accessible labels for screen readers
- Tab components were missing semantic ARIA roles and state indicators
- Buttons lacked meaningful accessible names
- No keyboard navigation support for interactive elements

### Solution
Implemented comprehensive accessibility improvements across 3 key files:

**LandingScreen.jsx**
- Added `aria-labelledby` to hero sliders (monthly contribution & savings duration)
- Added descriptive `aria-label` attributes to all CTA buttons

**RetirementSnapshot.jsx**
- Implemented full ARIA tab pattern (`role="tablist"`, `role="tab"`, `role="tabpanel"`)
- Added keyboard navigation: Arrow keys, Home/End, Tab, Enter/Space support
- Proper focus management on tab switches
- State management with `aria-selected` and `aria-controls`

**AutoloanCard.jsx**
- Added `aria-labelledby` to loan amount slider
- Added `aria-expanded`/`aria-controls` to toggle elements
- Descriptive `aria-label` on all 8 interactive buttons (including dynamic labels)

### Testing
- ✅ All sliders have meaningful labels
- ✅ Tabs follow ARIA tab pattern with full keyboard support
- ✅ All buttons have accessible names
- ✅ No UI/visual changes introduced
- ✅ No breaking changes to existing functionality
- ✅ Dev server runs without errors

### Compliance
Follows WCAG 2.1 guidelines for proper ARIA usage and keyboard accessibility.