### PR TITLE
test: add unit tests for calcular_proyeccion

### DIFF
--- a/manana-seguro-bot/test_proyeccion.py
+++ b/manana-seguro-bot/test_proyeccion.py
@@ -1,0 +1,59 @@
+import pytest
+
+from bot import calcular_proyeccion
+
+
+def test_carlos_scenario_projection_is_stable():
+    result = calcular_proyeccion(25, 20)
+
+    assert result["balance_final"] == pytest.approx(10269.15, abs=0.01)
+
+
+def test_minimum_deposit_five_years():
+    result = calcular_proyeccion(2, 5)
+
+    assert result["balance_final"] == pytest.approx(136.02, abs=0.01)
+    assert result["incentivos"] > 0
+
+
+def test_maximum_deposit_forty_years():
+    result = calcular_proyeccion(500, 40)
+
+    assert result["balance_final"] == pytest.approx(761597.59, abs=0.01)
+    assert result["balance_final"] > result["total_aportado"]
+
+
+def test_total_aportado_formula_matches_input():
+    mensual = 37.5
+    anios = 13
+
+    result = calcular_proyeccion(mensual, anios)
+
+    assert result["total_aportado"] == pytest.approx(mensual * anios * 12, abs=0.01)
+
+
+def test_zero_incentive_removes_incentive_amount():
+    result = calcular_proyeccion(25, 20, incentivo_pct=0)
+
+    assert result["incentivos"] == pytest.approx(0.0, abs=0.01)
+
+
+def test_max_incentive_beats_zero_incentive_same_inputs():
+    zero = calcular_proyeccion(25, 20, incentivo_pct=0)
+    max_incentive = calcular_proyeccion(25, 20, incentivo_pct=9)
+
+    assert max_incentive["incentivos"] > zero["incentivos"]
+    assert max_incentive["balance_final"] > zero["balance_final"]
+
+
+def test_projection_response_contains_expected_keys():
+    result = calcular_proyeccion(25, 20)
+
+    assert set(result.keys()) == {
+        "balance_final",
+        "total_aportado",
+        "rendimiento",
+        "incentivos",
+        "en_pesos",
+        "ingreso_mensual",
+    }


### PR DESCRIPTION
## Closes #6

## Summary
Adds unit test coverage for `calcular_proyeccion` in `manana-seguro-bot/bot.py` — the core projection logic used by the Telegram bot, which previously had no automated tests.

## Root Cause
Missing tests around core financial projection behavior allowed potential regressions in compounding, incentives, and output structure to pass unnoticed.

## Fix
Added `test_proyeccion.py` with focused pytest coverage for:
- Carlos scenario
- Minimum and maximum deposit cases
- Zero incentive vs. max incentive
- `total_aportado` formula validation
- Response key contract validation

## Testing
```
cd manana-seguro-bot && pytest test_proyeccion.py -v
```
- ✅ 7 tests passed
- ✅ Tests run without `TELEGRAM_TOKEN` or `ANTHROPIC_API_KEY` set