### PR TITLE
extract core/proyecciones.py

### DIFF
--- a/manana-seguro-bot/bot.py
+++ b/manana-seguro-bot/bot.py
@@ -7,6 +7,16 @@ import asyncio
 import logging
 from anthropic import Anthropic
 from dotenv import load_dotenv
+
+from core.proyecciones import (
+    calcular_proyeccion,
+    INCENTIVE_SCENARIOS,
+    USER_RATE,
+    CETES_RATE,
+    MIN_DEPOSIT,
+    usd,
+    mxn,
+)
 from stellar_connection import get_account_info, verificar_contrato, CONTRACT_ID
 
 claude_client = Anthropic(api_key=os.environ.get("ANTHROPIC_API_KEY", ""))
@@ -28,19 +38,6 @@ logger = logging.getLogger(__name__)
 # ─── Config ───────────────────────────────────────────────────────────────────
 TELEGRAM_TOKEN = os.environ.get("TELEGRAM_TOKEN", "")
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
-
-# Constantes del modelo de negocio
-USER_RATE     = 4.7
-PLATFORM_RATE = 1.0
-CETES_RATE    = 5.7
-MIN_DEPOSIT   = 2
-
-INCENTIVE_SCENARIOS = {
-    "solo_fidelidad":        {"label": "Solo fidelidad",                   "pct": 5},
-    "fidelidad_constancia":  {"label": "Fidelidad + constancia ($20/mes)", "pct": 7},
-    "fidelidad_1_referido":  {"label": "Fidelidad + 1 referido",           "pct": 6},
-    "fidelidad_2_referidos": {"label": "Fidelidad + 2 referidos",          "pct": 7},
-}
 
 # Estados
 (
@@ -74,42 +71,6 @@ Reglas:
 - Usa emojis para hacerlo visual
 - Máximo 200 palabras por respuesta
 - Al final sugiere una acción: /simular, /saldo, o /depositar"""
-
-# ─── Utilidades ───────────────────────────────────────────────────────────────
-
-def calcular_proyeccion(mensual, anios, tasa=USER_RATE, incentivo_pct=7):
-    monthly_rate = tasa / 100 / 12
-    balance = 0.0
-    total_yield = 0.0
-    incentivos = 0.0
-
-    for _ in range(anios // 5):
-        ciclo_yield = 0.0
-        for _ in range(60):
-            interest = balance * monthly_rate
-            balance += mensual + interest
-            ciclo_yield += interest
-            total_yield += interest
-        inc = ciclo_yield * incentivo_pct / 100
-        balance += inc
-        incentivos += inc
-
-    for _ in range((anios % 5) * 12):
-        interest = balance * monthly_rate
-        balance += mensual + interest
-        total_yield += interest
-
-    return {
-        "balance_final":   round(balance, 2),
-        "total_aportado":  round(mensual * anios * 12, 2),
-        "rendimiento":     round(total_yield, 2),
-        "incentivos":      round(incentivos, 2),
-        "en_pesos":        round(balance * 17, 0),
-        "ingreso_mensual": round(balance * 0.04 / 12, 2),
-    }
-
-def usd(n): return f"${n:,.2f} USDC"
-def mxn(n): return f"${n:,.0f} pesos"
 
 def teclado_principal():
     return ReplyKeyboardMarkup([

--- a/manana-seguro-bot/core/proyecciones.py
+++ b/manana-seguro-bot/core/proyecciones.py
@@ -1,0 +1,51 @@
+USER_RATE = 4.7
+PLATFORM_RATE = 1.0
+CETES_RATE = 5.7
+MIN_DEPOSIT = 2
+
+INCENTIVE_SCENARIOS = {
+    "solo_fidelidad":        {"label": "Solo fidelidad",                   "pct": 5},
+    "fidelidad_constancia":  {"label": "Fidelidad + constancia ($20/mes)", "pct": 7},
+    "fidelidad_1_referido":  {"label": "Fidelidad + 1 referido",           "pct": 6},
+    "fidelidad_2_referidos": {"label": "Fidelidad + 2 referidos",          "pct": 7},
+}
+
+
+def calcular_proyeccion(mensual, anios, tasa=USER_RATE, incentivo_pct=7):
+    monthly_rate = tasa / 100 / 12
+    balance = 0.0
+    total_yield = 0.0
+    incentivos = 0.0
+
+    for _ in range(anios // 5):
+        ciclo_yield = 0.0
+        for _ in range(60):
+            interest = balance * monthly_rate
+            balance += mensual + interest
+            ciclo_yield += interest
+            total_yield += interest
+        inc = ciclo_yield * incentivo_pct / 100
+        balance += inc
+        incentivos += inc
+
+    for _ in range((anios % 5) * 12):
+        interest = balance * monthly_rate
+        balance += mensual + interest
+        total_yield += interest
+
+    return {
+        "balance_final":   round(balance, 2),
+        "total_aportado":  round(mensual * anios * 12, 2),
+        "rendimiento":     round(total_yield, 2),
+        "incentivos":      round(incentivos, 2),
+        "en_pesos":        round(balance * 17, 0),
+        "ingreso_mensual": round(balance * 0.04 / 12, 2),
+    }
+
+
+def usd(n):
+    return f"${n:,.2f} USDC"
+
+
+def mxn(n):
+    return f"${n:,.0f} pesos"

--- a/manana-seguro-bot/test_proyeccion.py
+++ b/manana-seguro-bot/test_proyeccion.py
@@ -1,6 +1,6 @@
 import pytest
 
-from bot import calcular_proyeccion
+from core.proyecciones import calcular_proyeccion
 
 
 def test_carlos_scenario_projection_is_stable():


### PR DESCRIPTION
Extract projection logic into core/proyecciones.py
- Move `calcular_proyeccion`, `INCENTIVE_SCENARIOS`, rate constants, and formatter helpers from bot.py into core/
- bot.py now imports from core.proyecciones — no duplication
- Update test_proyeccion.py import path
- No new dependencies
Or if you want the full issue-linked format:
extract core/proyecciones.py

Closes #12 