### PR TITLE
feat(i18n): auto-detect browser language with localStorage persistence (closes #29)

### DIFF
--- a/CreditRoot/package.json
+++ b/CreditRoot/package.json
@@ -19,6 +19,7 @@
     "bootstrap": "^5.3.8",
     "clsx": "^2.1.1",
     "i18next": "^26.0.8",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lucide-react": "^1.14.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/CreditRoot/src/components/layout/AppHeader.jsx
+++ b/CreditRoot/src/components/layout/AppHeader.jsx
@@ -15,7 +15,9 @@ export function AppHeader({ usuario, onLogout }) {
   const [menuOpen, setMenuOpen] = useState(false)
 
   function toggleLang() {
-    i18n.changeLanguage(i18n.language === 'es' ? 'en' : 'es')
+    const next = i18n.language === 'es' ? 'en' : 'es'
+    i18n.changeLanguage(next)
+    localStorage.setItem('ms-lang', next)
   }
 
   function handleNavigate(href) {

--- a/CreditRoot/src/i18n/index.js
+++ b/CreditRoot/src/i18n/index.js
@@ -1,5 +1,6 @@
 import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
 import es from './es.json'
 import en from './en.json'
 
@@ -23,12 +24,22 @@ const getInitialLanguage = () => {
 const initialLanguage = getInitialLanguage()
 
 i18n
+  .use(LanguageDetector)
   .use(initReactI18next)
   .init({
     resources: { es: { translation: es }, en: { translation: en } },
     lng: initialLanguage,
     fallbackLng: 'es',
     interpolation: { escapeValue: false },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      lookupLocalStorage: 'ms-lang',
+      caches: ['localStorage'],
+      convertDetectedLanguage: (lang) => {
+        if (lang && lang.startsWith('en')) return 'en'
+        return 'es'
+      },
+    },
   })
 
 // Save language preference to localStorage whenever it changes


### PR DESCRIPTION
## Summary

Re-submission of #40 (closed due to rebase force-push issue). Same changes, clean branch from latest main.

Auto-detects the user's browser language on init and persists manual language toggles in `localStorage`, so the app remembers the user's preference across sessions.

## Changes

### 1. `CreditRoot/src/i18n/index.js`
- Added `i18next-browser-languagedetector` via `.use(LanguageDetector)`
- Configured detection:
  - `order: ['localStorage', 'navigator']` — reads `localStorage.getItem('ms-lang')` first, falls back to `navigator.language`
  - `lookupLocalStorage: 'ms-lang'`
  - `convertDetectedLanguage` — if browser language starts with `en`, use `en`; otherwise default to `es`
- `fallbackLng` stays `es`

### 2. `CreditRoot/package.json`
- Added `"i18next-browser-languagedetector": "^8.2.1"` to dependencies

### 3. `CreditRoot/src/components/layout/AppHeader.jsx`
- Updated `toggleLang()` to persist user choice: `localStorage.setItem('ms-lang', next)`

## Acceptance Criteria (Issue #29)

- [x] On init, read `localStorage.getItem('ms-lang')` first
- [x] If absent, parse `navigator.language` — if starts with `en`, use `en`; else default `es`
- [x] When user toggles language in navbar, write to `localStorage.setItem('ms-lang', lang)`
- [x] `fallbackLng` stays `es`
- [x] Added `i18next-browser-languagedetector` to dependencies

Closes #29.