### PR TITLE
test: add Vitest tests for useYieldCounter hook

### DIFF
--- a/CreditRoot/src/hooks/useYieldCounter.test.js
+++ b/CreditRoot/src/hooks/useYieldCounter.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useYieldCounterDirectMxn } from './useYieldCounter'
+
+describe('useYieldCounterDirectMxn', () => {
+  const MS_PER_YEAR = 365 * 24 * 60 * 60 * 1000
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Set a fixed system time for determinism: 2026-06-24 10:00:00
+    const mockDate = new Date(2026, 5, 24, 10, 0, 0)
+    vi.setSystemTime(mockDate)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe('Paused state', () => {
+    it('should return paused state when running=false', () => {
+      const { result } = renderHook(() => useYieldCounterDirectMxn(1000, 5, false))
+      
+      expect(result.current.isGrowing).toBe(false)
+      expect(result.current.yieldTodayMxn).toBe(0)
+      expect(result.current.displayBalance).toBe(1000)
+    })
+
+    it('should return paused state when realBalance <= 0', () => {
+      const { result } = renderHook(() => useYieldCounterDirectMxn(0, 5, true))
+      
+      expect(result.current.isGrowing).toBe(false)
+      expect(result.current.yieldTodayMxn).toBe(0)
+      expect(result.current.displayBalance).toBe(0)
+    })
+  })
+
+  describe('Growing state', () => {
+    it('should increase displayBalance over time when running=true and realBalance > 0', () => {
+      const { result } = renderHook(() => useYieldCounterDirectMxn(1000, 10, true))
+      
+      const initialBalance = result.current.displayBalance
+      
+      act(() => {
+        vi.advanceTimersByTime(1000) // 1 second
+      })
+      
+      expect(result.current.isGrowing).toBe(true)
+      expect(result.current.displayBalance).toBeGreaterThan(initialBalance)
+    })
+  })
+
+  describe('Per millisecond growth', () => {
+    it('should match the expected growth rate (annualYieldRate / 100 / msPerYear)', () => {
+      const realBalance = 1000000 // 1M for precision
+      const annualYieldRate = 10 // 10%
+      
+      const { result } = renderHook(() => useYieldCounterDirectMxn(realBalance, annualYieldRate, true))
+      
+      // Initial yield at 10:00:00 (10 hours since midnight)
+      const initialYield = result.current.yieldTodayMxn
+      
+      const advanceMs = 10000 // 10 seconds
+      act(() => {
+        vi.advanceTimersByTime(advanceMs)
+      })
+      
+      const ratePerMs = (annualYieldRate / 100) / MS_PER_YEAR
+      const expectedGrowth = realBalance * ratePerMs * advanceMs
+      const actualGrowth = result.current.yieldTodayMxn - initialYield
+      
+      // Using toBeCloseTo for float precision
+      expect(actualGrowth).toBeCloseTo(expectedGrowth, 8)
+    })
+  })
+
+  describe('Midnight reset', () => {
+    it('should reset yieldTodayMxn correctly when advancing across midnight', () => {
+      // Set time to 23:59:50
+      const almostMidnight = new Date(2026, 5, 24, 23, 59, 50)
+      vi.setSystemTime(almostMidnight)
+      
+      const { result } = renderHook(() => useYieldCounterDirectMxn(1000, 10, true))
+      
+      expect(result.current.yieldTodayMxn).toBeGreaterThan(0)
+      
+      // Advance by 20 seconds to cross midnight (into 2026-06-25 00:00:10)
+      act(() => {
+        vi.advanceTimersByTime(20000)
+      })
+      
+      // At 00:00:10, yieldTodayMxn should only represent 10 seconds of growth
+      const ratePerMs = (10 / 100) / MS_PER_YEAR
+      const expectedYieldAfterMidnight = 1000 * ratePerMs * 10000
+      
+      expect(result.current.yieldTodayMxn).toBeCloseTo(expectedYieldAfterMidnight, 8)
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces a comprehensive, production-grade test suite for the useYieldCounterDirectMxn hook. The goal was to ensure the financial logic governing real-time yield growth and midnight resets is 100% deterministic, fast, and free of flakiness.

The tests leverage Vitest fake timers to simulate time passage without real-world waiting, ensuring the suite remains "Drips Ready" and highly performant.
 Key Changes
- Created src/hooks/useYieldCounter.test.js : A new test file dedicated to the yield counter logic.
- Deterministic Time Mocking : Implemented vi.useFakeTimers() and vi.setSystemTime() to control the "system clock" precisely.
- Midnight Boundary Testing : Specifically verified that yieldTodayMxn resets to near-zero (only accounting for ms passed since 00:00:00) when the clock crosses midnight.
- Growth Rate Validation : Mathematically verified that the interest accrued matches the formula: (annualYieldRate / 100) / msPerYear . Test Scenarios Covered
- Paused State : Validates that when running=false or realBalance <= 0 , growth stops and yieldTodayMxn stays at 0.
- Active Growth : Confirms isGrowing is true and displayBalance increases over time.
- Precision Calculation : Uses toBeCloseTo to verify floating-point accuracy of the yield per millisecond.
- Midnight Reset : Mocks a jump across midnight to ensure the "Today's Yield" derivation correctly switches to the new day's start time. Testing Stack
- Vitest : Test runner and mocking.
- @testing-library/react : renderHook for testing the hook in isolation.
- Fake Timers : For instantaneous testing of time-based intervals. Verification Results
- Speed : Tests run in milliseconds.
- Determinism : No usage of sleep() or real setTimeout .
- Reliability : Fixed system time prevents tests from failing based on the time of day they are run.
Reviewer Note : The hook itself remains untouched as per requirements; the focus was entirely on ensuring the existing logic is robustly verified.



closes #62 