### PR TITLE
refactor: extract magic numbers to constants in calcular_proyeccion

### DIFF
--- a/manana-seguro-bot/core/proyecciones.py
+++ b/manana-seguro-bot/core/proyecciones.py
@@ -3,6 +3,13 @@ PLATFORM_RATE = 1.0
 CETES_RATE = 5.7
 MIN_DEPOSIT = 2
 
+MONTHS_PER_YEAR = 12
+YEARS_PER_CYCLE = 5
+MONTHS_PER_CYCLE = YEARS_PER_CYCLE * MONTHS_PER_YEAR
+DEFAULT_INCENTIVE_PCT = 7
+USD_TO_MXN_RATE = 17
+SAFE_WITHDRAWAL_RATE = 0.04
+
 INCENTIVE_SCENARIOS = {
     "solo_fidelidad":        {"label": "Solo fidelidad",                   "pct": 5},
     "fidelidad_constancia":  {"label": "Fidelidad + constancia ($20/mes)", "pct": 7},
@@ -11,15 +18,15 @@ INCENTIVE_SCENARIOS = {
 }
 
 
-def calcular_proyeccion(mensual, anios, tasa=USER_RATE, incentivo_pct=7):
-    monthly_rate = tasa / 100 / 12
+def calcular_proyeccion(mensual, anios, tasa=USER_RATE, incentivo_pct=DEFAULT_INCENTIVE_PCT):
+    monthly_rate = tasa / 100 / MONTHS_PER_YEAR
     balance = 0.0
     total_yield = 0.0
     incentivos = 0.0
 
-    for _ in range(anios // 5):
+    for _ in range(anios // YEARS_PER_CYCLE):
         ciclo_yield = 0.0
-        for _ in range(60):
+        for _ in range(MONTHS_PER_CYCLE):
             interest = balance * monthly_rate
             balance += mensual + interest
             ciclo_yield += interest
@@ -28,18 +35,18 @@ def calcular_proyeccion(mensual, anios, tasa=USER_RATE, incentivo_pct=7):
         balance += inc
         incentivos += inc
 
-    for _ in range((anios % 5) * 12):
+    for _ in range((anios % YEARS_PER_CYCLE) * MONTHS_PER_YEAR):
         interest = balance * monthly_rate
         balance += mensual + interest
         total_yield += interest
 
     return {
         "balance_final":   round(balance, 2),
-        "total_aportado":  round(mensual * anios * 12, 2),
+        "total_aportado":  round(mensual * anios * MONTHS_PER_YEAR, 2),
         "rendimiento":     round(total_yield, 2),
         "incentivos":      round(incentivos, 2),
-        "en_pesos":        round(balance * 17, 0),
-        "ingreso_mensual": round(balance * 0.04 / 12, 2),
+        "en_pesos":        round(balance * USD_TO_MXN_RATE, 0),
+        "ingreso_mensual": round(balance * SAFE_WITHDRAWAL_RATE / MONTHS_PER_YEAR, 2),
     }
 
 


### PR DESCRIPTION
hey, extracted those magic numbers inside the `calcular_proyeccion` function and defined them as constants at the top of the file. it makes the math logic much easier to read now.

also ran the tests locally and everything still passes fine!

Closes #59