### PR TITLE
test: add unit tests for contribution history utility functions

### DIFF
--- a/CreditRoot/package-lock.json
+++ b/CreditRoot/package-lock.json
@@ -2597,6 +2597,26 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2659,6 +2679,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2951,6 +2978,16 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -3234,6 +3271,20 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bufferutil": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
+      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/call-bind": {
@@ -3593,6 +3644,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5103,6 +5161,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5220,6 +5288,18 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -5423,6 +5503,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -5501,6 +5609,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -6138,6 +6253,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
+      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/uuid": {

--- a/CreditRoot/src/features/dashboard/components/contributionHistoryUtils.test.js
+++ b/CreditRoot/src/features/dashboard/components/contributionHistoryUtils.test.js
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  buildHistoryEntry,
+  addHistoryEntry,
+  loadHistory,
+  saveHistory
+} from './contributionHistoryUtils';
+import { MANANA_SEGURO_RATES } from '../../../data/retirementContent';
+
+describe('contributionHistoryUtils', () => {
+  let mockStorage = {};
+
+  const localStorageMock = {
+    getItem: vi.fn((key) => mockStorage[key] ?? null),
+    setItem: vi.fn((key, value) => {
+      mockStorage[key] = value.toString();
+    }),
+    clear: vi.fn(() => {
+      mockStorage = {};
+    }),
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal('localStorage', localStorageMock);
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  describe('loadHistory', () => {
+    it('returns [] when storage is empty', () => {
+      const history = loadHistory('test-wallet');
+      expect(history).toEqual([]);
+    });
+
+    it('parses stored JSON otherwise', () => {
+      const data = [{ id: 1, amount: 10 }];
+      mockStorage['manana_seguro_history_test-wallet'] = JSON.stringify(data);
+      const history = loadHistory('test-wallet');
+      expect(history).toEqual(data);
+    });
+
+    it('returns [] when localStorage throws', () => {
+      localStorageMock.getItem.mockImplementationOnce(() => {
+        throw new Error('Access denied');
+      });
+      const history = loadHistory('test-wallet');
+      expect(history).toEqual([]);
+    });
+  });
+
+  describe('saveHistory', () => {
+    it('writes under the wallet-scoped key', () => {
+      const data = [{ id: 1, amount: 10 }];
+      saveHistory('test-wallet', data);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'manana_seguro_history_test-wallet',
+        JSON.stringify(data)
+      );
+      expect(mockStorage['manana_seguro_history_test-wallet']).toBe(JSON.stringify(data));
+    });
+
+    it('uses demo as fallback wallet', () => {
+      const data = [{ id: 1, amount: 10 }];
+      saveHistory(null, data);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'manana_seguro_history_demo',
+        JSON.stringify(data)
+      );
+    });
+
+    it('does not throw when storage is unavailable', () => {
+      localStorageMock.setItem.mockImplementationOnce(() => {
+        throw new Error('Storage full');
+      });
+      expect(() => saveHistory('test-wallet', [])).not.toThrow();
+    });
+  });
+
+  describe('buildHistoryEntry', () => {
+    it('with empty history, balanceAfter equals the deposit amount plus zero yield', () => {
+      const entry = buildHistoryEntry(100, 'test-wallet');
+      expect(entry.amount).toBe(100);
+      expect(entry.yieldAccrued).toBe(0);
+      expect(entry.balanceAfter).toBe(100);
+      expect(entry.type).toBe('deposito');
+      expect(entry.confirmed).toBe(true);
+    });
+
+    it('with prior history, yield is prevBalance * monthlyRate and balanceAfter compounds correctly', () => {
+      const prevBalance = 1000;
+      mockStorage['manana_seguro_history_test-wallet'] = JSON.stringify([
+        { id: 1, balanceAfter: prevBalance }
+      ]);
+
+      const monthlyRate = MANANA_SEGURO_RATES.userRate / 100 / 12;
+      const expectedYield = parseFloat((prevBalance * monthlyRate).toFixed(4));
+      const depositAmount = 50;
+
+      const entry = buildHistoryEntry(depositAmount, 'test-wallet');
+
+      expect(entry.amount).toBe(depositAmount);
+      expect(entry.yieldAccrued).toBe(expectedYield);
+      expect(entry.balanceAfter).toBe(parseFloat((prevBalance + depositAmount + expectedYield).toFixed(4)));
+    });
+  });
+
+  describe('addHistoryEntry', () => {
+    it('prepends the new entry (newest first) and persists', () => {
+      const existingEntry = { id: 1, amount: 50, balanceAfter: 50 };
+      mockStorage['manana_seguro_history_test-wallet'] = JSON.stringify([existingEntry]);
+
+      const newEntry = { id: 2, amount: 100, balanceAfter: 150 };
+      const result = addHistoryEntry('test-wallet', newEntry);
+
+      expect(result).toEqual([newEntry, existingEntry]);
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        'manana_seguro_history_test-wallet',
+        JSON.stringify([newEntry, existingEntry])
+      );
+    });
+  });
+});


### PR DESCRIPTION
I created a comprehensive unit testing suite using Vitest for the `contributionHistoryUtils.js` module by implementing a manual mock of `localStorage` to simulate storage behavior without needing a real browser. The new `contributionHistoryUtils.test.js` file thoroughly covers the acceptance criteria: it verifies `buildHistoryEntry` accurately calculates yields and compounding balances based on prior history, ensures `addHistoryEntry` correctly prepends and persists new deposits, and confirms `loadHistory` and `saveHistory` gracefully handle data parsing and storage unavailability. All tests passed successfully after ensuring the local project dependencies were fully installed.


Close #57 